### PR TITLE
feature: Add Pipenv for execution

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+btrfs = "*"
+
+[requires]
+python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,28 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "472eba7ddb71405d72e3429ede506ed00c4ed90cdcf9380660335805ae0d1e0d"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "btrfs": {
+            "hashes": [
+                "sha256:3dc3404438e8d568eecd343d10e12cf38a314730b91771fef3a3787e88d422f1"
+            ],
+            "index": "pypi",
+            "version": "==11"
+        }
+    },
+    "develop": {}
+}

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ To run the program, you need to clone two git repositories:
 The fastest way to get it running is:
 ```
 -$ git clone https://github.com/knorrie/btrfs-heatmap.git
--$ git clone https://github.com/knorrie/python-btrfs.git
 -$ cd btrfs-heatmap
-btrfs-heatmap (master) -$ ln -s ../python-btrfs/btrfs/
-btrfs-heatmap (master) -$ sudo ./heatmap.py /mountpoint
+btrfs-heatmap (master) -$ pipenv install
+btrfs-heatmap (master) -$ sudo $(which pipenv) run ./heatmap.py /mountpoint
 ```
 
 When pointing heatmap.py to a mounted btrfs filesystem location, it will ask

--- a/heatmap.py
+++ b/heatmap.py
@@ -1,4 +1,5 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
+
 #
 # Copyright (C) 2016 Hans van Kranenburg <hans@knorrie.org>
 #
@@ -21,14 +22,17 @@
 # TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 # SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+# Std. lib imports
 import argparse
-import btrfs
 import errno
 import os
 import struct
 import sys
 import types
 import zlib
+
+# PyPI imports
+import btrfs
 
 
 class HeatmapError(Exception):


### PR DESCRIPTION
Just a suggestion on how to use `Pipenv` to ensure that the program runs with its dependencies on anyone's computer.

NB: Given that they have `Pipenv` and `python3` installed. (I belive `Pipenv` might force `python3.7`, but that can be looked into if you so desire).